### PR TITLE
Removed duplicate study.

### DIFF
--- a/offline_data_parsing/research.json
+++ b/offline_data_parsing/research.json
@@ -1328,15 +1328,6 @@
 		"quote": "These data [of mice models] suggest that macrophages in WAT [White adipose tissue] play an active role in morbid obesity and that macrophage-related inflammatory activities may contribute to the pathogenesis of obesity-induced insulin resistance. We propose that obesity-related insulin resistance is, at least in part, a chronic inflammatory disease initiated in adipose tissue."
 	},
 	{
-		"title": "A two-year randomized weight loss trial comparing a vegan diet to a more moderate low-fat diet.",
-		"url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2988700/",
-		"year": 2007,
-		"type": "study",
-		"availability": "abstract",
-		"tags": "weight loss,vegan",
-		"quote": "Individuals in the vegan group lost more weight than those in the NCEP group at 1 year [-4.9 (-0.5, -8.0) kg vs. -1.8 (0.8, -4.3); p < 0.05] and at 2 years [-3.1 (0.0, -6.0) kg vs. -0.8 (3.1, -4.2) kg; p < 0.05]. "
-	},
-	{
 		"title": "Everything in Moderation - Dietary Diversity and Quality, Central Obesity and Risk of Diabetes",
 		"url": "http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0141341",
 		"year": 2015,


### PR DESCRIPTION
There were two entries for "A Two-Year Randomized Weight Loss Trial Comparing a Vegan Diet to a More Moderate Low-Fat Diet". They had different sources as one was full text and the other abstract only, but I don't think there's a reason to keep the abstract only one. Maybe we should add DOI as a unique key to prevent this in future, but that is probably unnecessary & overkill.